### PR TITLE
fix: add missing Dynatrace, Mastering, Docker badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ author: Tony Pope-Cruz
 
 # Enablement OpenPipeline, Segments, and IAM Policies
 
+[![Dynatrace](https://img.shields.io/badge/Dynatrace-Intelligence-purple?logo=dynatrace&logoColor=white)](https://dynatrace-wwse.github.io/codespaces-framework/dynatrace-integration/#mcp-server-integration)
+[![Mastering](https://img.shields.io/badge/Mastering-Complexity-8A2BE2?logo=dynatrace)](https://dynatrace-wwse.github.io)
+[![Downloads](https://img.shields.io/docker/pulls/shinojosa/dt-enablement?logo=docker)](https://hub.docker.com/r/shinojosa/dt-enablement)
 [![Integration tests](https://github.com/dynatrace-wwse/enablement-openpipeline-segments-iam/actions/workflows/integration-tests.yaml/badge.svg)](https://github.com/dynatrace-wwse/enablement-openpipeline-segments-iam/actions)
 [![Version](https://img.shields.io/github/v/release/dynatrace-wwse/enablement-openpipeline-segments-iam?color=blueviolet)](https://github.com/dynatrace-wwse/enablement-openpipeline-segments-iam/releases)
 [![Commits](https://img.shields.io/github/commits-since/dynatrace-wwse/enablement-openpipeline-segments-iam/latest?color=ff69b4&include_prereleases)](https://github.com/dynatrace-wwse/enablement-openpipeline-segments-iam/graphs/commit-activity)


### PR DESCRIPTION
Adds Dynatrace Intelligence, Mastering Complexity, and Docker Downloads badges to match the standard badge set across all repos.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>