### PR TITLE
docs: remove per-page JS RUM snippets, update main.html for auto page tracking

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,3 +8,16 @@
     crossorigin="anonymous"></script>
   {% endif %}
 {% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% if config.extra.rum_snippet and page is defined and page.title %}
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      if (typeof dynatrace !== 'undefined') {
+        dynatrace.sendBizEvent('page_load', {'page': {{ page.title | tojson }}});
+      }
+    });
+  </script>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary

- Removes all `docs/snippets/*.js` files (per-page RUM bizEvent scripts)
- Removes `--8<-- "snippets/*.js"` includes from all markdown pages
- Updates `docs/overrides/main.html` to the framework v1.3.0 template

## Why

Page tracking via BizEvents is now handled centrally by `docs/overrides/main.html`, which:
1. Loads the RUM agent from `extra.rum_snippet` in `mkdocs.yaml`
2. Fires a `page_load` BizEvent on every page using the page title from the `nav` definition

Per-page JS snippet files were redundant and required manual maintenance for each new page.

## Test plan
- [ ] Verify docs build succeeds in CI
- [ ] Confirm no broken snippet includes remain in markdown files

🤖 Generated with [Claude Code](https://claude.com/claude-code)